### PR TITLE
Add GitHub Pages deployment with GitHub Actions

### DIFF
--- a/.github/DEPLOYMENT.md
+++ b/.github/DEPLOYMENT.md
@@ -1,0 +1,57 @@
+# GitHub Pages Deployment
+
+This project is configured to automatically deploy to GitHub Pages using GitHub Actions.
+
+## Setup Instructions
+
+### 1. Enable GitHub Pages
+
+1. Go to your repository on GitHub
+2. Click on **Settings**
+3. Navigate to **Pages** in the left sidebar
+4. Under **Source**, select **GitHub Actions**
+
+### 2. Trigger Deployment
+
+The workflow will automatically run when you:
+- Push to the `main` or `master` branch
+- Manually trigger it from the Actions tab
+
+### 3. Access Your Site
+
+Once deployed, your site will be available at:
+```
+https://[your-username].github.io/cost-of-duty/
+```
+
+## How It Works
+
+The deployment workflow:
+1. Checks out the repository
+2. Sets up Node.js 14 (required for legacy dependencies)
+3. Installs dependencies with `npm ci --legacy-peer-deps`
+4. Builds the project with `npm run build`
+5. Deploys the `dist` folder to GitHub Pages
+
+## Configuration
+
+### Base Path
+The app is configured to run at `/cost-of-duty/` path. This is set in:
+- `config/index.js` - `assetsPublicPath`
+
+### Router Mode
+The Vue Router uses **hash mode** (`/#/`) to ensure routing works on GitHub Pages without server-side configuration.
+
+## Troubleshooting
+
+### Build Fails
+- The project uses Node.js 14 due to legacy dependencies (node-sass)
+- The build uses `--openssl-legacy-provider` flag for compatibility
+
+### 404 Errors
+- Make sure GitHub Pages is set to use **GitHub Actions** as the source
+- Check that the base path in `config/index.js` matches your repository name
+
+### API Issues
+- The app uses a CORS proxy to access the Call of Duty API
+- If the proxy is down, you may need to update the `corsProxy` URL in `src/pages/TestPlayer.vue`

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,59 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches:
+      - main
+      - master
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '14'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci --legacy-peer-deps
+
+      - name: Build project
+        run: npm run build
+        env:
+          NODE_OPTIONS: --openssl-legacy-provider
+
+      - name: Setup Pages
+        uses: actions/configure-pages@v4
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: './dist'
+
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/config/index.js
+++ b/config/index.js
@@ -50,7 +50,9 @@ module.exports = {
     // Paths
     assetsRoot: path.resolve(__dirname, '../dist'),
     assetsSubDirectory: 'static',
-    assetsPublicPath: '/',
+    assetsPublicPath: process.env.NODE_ENV === 'production'
+      ? '/cost-of-duty/'
+      : '/',
 
     /**
      * Source Maps

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -8,6 +8,8 @@ import Page404 from '@/pages/Page404'
 Vue.use(Router)
 
 export default new Router({
+    mode: 'hash',
+    base: process.env.BASE_URL,
     routes: [{
             path: '/',
             name: 'Home',


### PR DESCRIPTION
This commit adds automated deployment to GitHub Pages using GitHub Actions. The workflow builds the Vue.js application and deploys it to GitHub Pages.

Changes:
- Add GitHub Actions workflow for automated deployment
- Configure build to use correct base path for GitHub Pages (/cost-of-duty/)
- Update Vue Router to use hash mode for GitHub Pages compatibility
- Add .nojekyll file to prevent Jekyll processing
- Add deployment documentation

The workflow:
- Uses Node.js 14 for compatibility with legacy dependencies
- Installs dependencies with --legacy-peer-deps flag
- Builds the project with npm run build
- Deploys the dist folder to GitHub Pages

Setup required:
1. Go to repository Settings > Pages
2. Set Source to "GitHub Actions"
3. Push to main/master branch or trigger manually

Site will be available at: https://[username].github.io/cost-of-duty/